### PR TITLE
Fix spacing issue when using navigation.sections without navigation.tabs

### DIFF
--- a/tech_docs_template/assets/stylesheets/extra.css
+++ b/tech_docs_template/assets/stylesheets/extra.css
@@ -99,8 +99,10 @@
   border-left-color:   #1d70b8;
 }
 
+.md-nav__item--section > .md-nav > .md-nav__list > .md-nav__item--active,
 .md-nav--secondary .md-nav__link--active {
   /* font-weight: 700;  */
+  margin-left:  0;
   padding-left: 3px;
   border-left: 3px solid;
   border-left-color:   #1d70b8;


### PR DESCRIPTION
When using navigation.sections without navigation.tabs, there were two issues:

- The vertical blue bar to indicate the active item was squashed against the text
- The text and bar were too far to the right, not being consistent with the case of not using sections where the where the text would only move a little bit, making room for the blue bar

This fixes both of these issues by

- Using margin-left: 0 to make the text and bar move less to the right
- Using a more specific CSS selector to override more of the default material design styles

This shows the issue before this PR, which are the docs for this template itself, but changed to use sections but no tabs
<img width="1403" alt="sections-without-tabs-issue" src="https://user-images.githubusercontent.com/13877/222357287-f1d1d502-a1c5-4bd3-9971-594af34ce46d.png">

And this shows the docs using the code in this PR

<img width="1403" alt="sections-without-tabs-fixed" src="https://user-images.githubusercontent.com/13877/222357306-980100ae-2c11-45a7-8396-cdf63df3a3c3.png">

This should address https://github.com/ministryofjustice/mkdocs-tech-docs-template/issues/12