### PR TITLE
Make blue border at the bottom of the black header full-width

### DIFF
--- a/tech_docs_template/assets/stylesheets/extra.css
+++ b/tech_docs_template/assets/stylesheets/extra.css
@@ -41,9 +41,6 @@
 /* Configure the header */
 .md-header{
   box-shadow: none;
-}
-
-.md-header__inner {
   border-bottom: 10px solid; 
   border-bottom-color:  #1d70b8;
 }
@@ -112,10 +109,11 @@
 .md-tabs {
   color: #1d70b8;
   background-color: #f8f8f8;
-  /* border-top: 10px solid; */
-  /* border-top-color:  #1d70b8; */
+  border-top: 10px solid;
+  border-top-color:  #1d70b8;
   border-bottom: 1px solid;
   border-bottom-color:  #b1b4b6;
+  margin-bottom: -10px;  /* Hide the border on .md-header */
   line-height: 1;
 }
 


### PR DESCRIPTION
(Hope it's ok to just... raise another PR. Let me know if no! Also the below description has been edited for posterity as the PR has been updated)

Existing GOV.UK styles sites seem to have one of two styles in terms of the blue bar

1. Exactly content width bar, just beneath the black header area (so there is white either side of the blue bar)

2. Full width blue bar beneath the black header area. This is common for documentation sites and sites that have tabs beneath the blue bar.

Before this change the blue bar was a 3rd style - a bit bigger than content width, and also "in" the black header area, so with black either side of it.

This change makes the blue bar the full-width style, since this template is more like 2. above, especially when tabs are enabled.

Note that to handle the cases of tabs enabled and tabs disabled, we have the blue bar on both the tabs element, and the header. To avoid the visual duplication, a negative margin is used. There doesn't seem to be a way of avoiding this with the material design mkdocs HTML structure.

### Full-width blue bar with tabs showing

![image](https://user-images.githubusercontent.com/13877/224395554-00c2ce62-0879-4049-88ab-be066d103874.png)

### Full-width blue bar without tabs showing

![image](https://user-images.githubusercontent.com/13877/224395272-5e1609ab-e0a5-4348-a7b2-f17421d30142.png)
