### PR TITLE
fix: allow beta mkdocs 9.2

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ packages = find:
 include_package_data = True
 zip_safe = False
 install_requires =
-	mkdocs-material >= 9.2
+	mkdocs-material >= 9.2.0b1
 
 [options.entry_points]
 mkdocs.themes =


### PR DESCRIPTION
It looks like mkdocs-tech-docs-template requires mkdocs-material 9.2 https://github.com/ministryofjustice/mkdocs-tech-docs-template/pull/43, but only beta versions have been released to PyPI so far, which appear less than 9.2 according to pip, making it impossible for mkdocs-tech-docs-template to be installed.

This change explicitly allows the released beta 9.2.0 versions, and so allows mkdocs-tech-docs-template to be installed.